### PR TITLE
feat(cart): add order notes and clarify estimated pricing

### DIFF
--- a/src/components/CartDrawer.vue
+++ b/src/components/CartDrawer.vue
@@ -126,13 +126,46 @@ const isEmpty = computed(() => cart.count.value === 0);
                 </div>
               </div>
             </div>
+
+            <div class="py-4 border-t border-gray-100 dark:border-gray-700">
+              <div class="flex items-center justify-between gap-3">
+                <label
+                  for="cart-order-notes"
+                  class="text-sm font-medium text-gray-700 dark:text-gray-200"
+                >
+                  {{ t("cart.orderNotes") }}
+                </label>
+                <span
+                  id="cart-order-notes-count"
+                  class="shrink-0 text-xs text-gray-400 dark:text-gray-500"
+                >
+                  {{ cart.orderNotes.value.length }}/{{ cart.orderNotesMaxLength }}
+                </span>
+              </div>
+              <textarea
+                id="cart-order-notes"
+                v-model="cart.orderNotes.value"
+                :maxlength="cart.orderNotesMaxLength"
+                :placeholder="t('cart.orderNotesPlaceholder')"
+                aria-describedby="cart-order-notes-count"
+                rows="4"
+                class="block w-full mt-2 px-3 py-2.5 text-sm leading-relaxed text-gray-800 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-xl resize-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:focus-visible:ring-accent-light focus-visible:border-transparent transition-colors"
+              ></textarea>
+            </div>
           </div>
 
           <!-- Footer -->
           <div v-if="!isEmpty" class="px-4 py-4 border-t border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
-            <div class="flex justify-between items-center mb-4">
-              <span class="text-gray-600 dark:text-gray-400">{{ t('cart.estimate') }}</span>
-              <span class="text-xl font-semibold text-gray-800 dark:text-gray-100">~{{ formatPrice(cart.total.value) }} lei</span>
+            <div class="mb-4">
+              <div class="flex justify-between items-center gap-3">
+                <span class="text-gray-600 dark:text-gray-400">{{ t("cart.estimate") }}</span>
+                <span class="shrink-0 text-xl font-semibold text-gray-800 dark:text-gray-100">
+                  ~{{ formatPrice(cart.total.value) }} lei
+                </span>
+              </div>
+              <p class="mt-1.5 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                {{ t("cart.estimateNote") }}
+              </p>
             </div>
             <a
               :href="cart.whatsappUrl.value"

--- a/src/composables/useCart.ts
+++ b/src/composables/useCart.ts
@@ -4,6 +4,7 @@ import { CONTACT } from "../constants";
 import { getCatalogProductMap, getProductId, type CatalogProduct } from "../data/catalogData";
 import type { Locale } from "../i18n";
 import { formatQuantityLabel, getQuantityStep, normalizeQuantity } from "../utils/quantity";
+import { trySetStorageItem } from "../utils/safeStorage";
 
 interface CartItemSnapshot {
   title: string;
@@ -150,18 +151,21 @@ function ensurePersistenceWatcher() {
   if (persistenceInitialized) return;
   persistenceInitialized = true;
 
+  const persist = (key: string, value: string) => {
+    if (typeof window === "undefined") return;
+    trySetStorageItem(() => window.localStorage, key, value);
+  };
+
   watch(
     storedItems,
     (newItems) => {
-      if (typeof localStorage === "undefined") return;
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(newItems));
+      persist(STORAGE_KEY, JSON.stringify(newItems));
     },
     { deep: true },
   );
 
   watch(orderNotes, (newNotes) => {
-    if (typeof localStorage === "undefined") return;
-    localStorage.setItem(ORDER_NOTES_STORAGE_KEY, newNotes);
+    persist(ORDER_NOTES_STORAGE_KEY, newNotes);
   });
 }
 
@@ -211,7 +215,9 @@ export function useCart() {
 
   const count = computed(() => storedItems.value.length);
 
-  const total = computed(() => items.value.reduce((sum, item) => sum + item.price * item.quantity, 0));
+  const total = computed(() =>
+    items.value.reduce((sum, item) => sum + item.price * item.quantity, 0),
+  );
 
   const whatsappUrl = computed(() => {
     if (storedItems.value.length === 0) return CONTACT.whatsapp;

--- a/src/composables/useCart.ts
+++ b/src/composables/useCart.ts
@@ -30,9 +30,12 @@ export interface CartItem {
 }
 
 const STORAGE_KEY = "homemadebydia_cart";
+const ORDER_NOTES_STORAGE_KEY = "homemadebydia_cart_notes";
+const ORDER_NOTES_MAX_LENGTH = 500;
 const drawerOpen = ref(false);
 const lastAdded = ref<string | null>(null);
 const storedItems = ref<StoredCartItem[]>([]);
+const orderNotes = ref("");
 const ROMANIAN_CATALOG_PRODUCT_MAP = getCatalogProductMap("ro");
 
 let initialized = false;
@@ -121,6 +124,17 @@ function loadFromStorage(): StoredCartItem[] {
   }
 }
 
+function loadOrderNotesFromStorage(): string {
+  if (typeof localStorage === "undefined") return "";
+
+  try {
+    const stored = localStorage.getItem(ORDER_NOTES_STORAGE_KEY);
+    return typeof stored === "string" ? stored.slice(0, ORDER_NOTES_MAX_LENGTH) : "";
+  } catch {
+    return "";
+  }
+}
+
 function repairStoredItemsForLocale(locale: Locale) {
   repairStoredItemsWithProductMap(getCatalogProductMap(locale));
 }
@@ -129,6 +143,7 @@ function ensureClientInitialization() {
   if (initialized || typeof window === "undefined") return;
   initialized = true;
   storedItems.value = loadFromStorage();
+  orderNotes.value = loadOrderNotesFromStorage();
 }
 
 function ensurePersistenceWatcher() {
@@ -143,6 +158,11 @@ function ensurePersistenceWatcher() {
     },
     { deep: true },
   );
+
+  watch(orderNotes, (newNotes) => {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(ORDER_NOTES_STORAGE_KEY, newNotes);
+  });
 }
 
 export function useCart() {
@@ -210,7 +230,9 @@ export function useCart() {
 
     if (lines.length === 0) return CONTACT.whatsapp;
 
-    const message = `Bună ziua! Aș dori să comand:\n${lines.join("\n")}\n\nMulțumesc!`;
+    const trimmedNotes = orderNotes.value.trim();
+    const notesSection = trimmedNotes ? `\n\nDetalii pentru comandă:\n${trimmedNotes}` : "";
+    const message = `Bună ziua! Aș dori să comand:\n${lines.join("\n")}${notesSection}\n\nMulțumesc!`;
 
     return `${CONTACT.whatsapp}?text=${encodeURIComponent(message)}`;
   });
@@ -258,6 +280,7 @@ export function useCart() {
 
   function clear() {
     storedItems.value = [];
+    orderNotes.value = "";
   }
 
   function has(id: string) {
@@ -277,6 +300,8 @@ export function useCart() {
     count,
     total,
     whatsappUrl,
+    orderNotes,
+    orderNotesMaxLength: ORDER_NOTES_MAX_LENGTH,
     add,
     update,
     remove,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -108,7 +108,10 @@
     "decreaseQuantity": "Decrease quantity",
     "increaseQuantity": "Increase quantity",
     "delete": "Remove",
-    "estimate": "Estimated total",
+    "estimate": "Estimate (indicative price)",
+    "estimateNote": "The estimate may vary based on the finished products' weight. Decorations and other customizations are agreed separately on WhatsApp, and the final price is provided at pickup.",
+    "orderNotes": "Order details (optional)",
+    "orderNotesPlaceholder": "Pickup on Saturday, October 17, around 3:00 PM. For the cake, I would like pink and cream decorations with butterflies and the inscription “Happy 6th birthday, Sofia!”.",
     "sendOnWhatsApp": "Send order on WhatsApp",
     "clearCart": "Clear cart",
     "addedToCart": "Added to cart"

--- a/src/i18n/ro.json
+++ b/src/i18n/ro.json
@@ -108,7 +108,10 @@
     "decreaseQuantity": "Scade cantitatea",
     "increaseQuantity": "Crește cantitatea",
     "delete": "Șterge",
-    "estimate": "Estimare",
+    "estimate": "Estimare (preț orientativ)",
+    "estimateNote": "Estimarea poate varia în funcție de greutatea produselor finite. Decorul și alte personalizări se stabilesc separat pe WhatsApp, iar prețul final se comunică la ridicare.",
+    "orderNotes": "Detalii pentru comandă (opțional)",
+    "orderNotesPlaceholder": "Ridicare sâmbătă, 17 octombrie, în jurul orei 15:00. Pentru tort aș dori un decor în nuanțe de roz și crem, cu fluturi și mesajul „La mulți ani, Sofia! 6 ani”.",
     "sendOnWhatsApp": "Trimite comanda pe WhatsApp",
     "clearCart": "Golește coșul",
     "addedToCart": "Adăugat în coș"

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,0 +1,16 @@
+interface StorageWriter {
+  setItem(key: string, value: string): void;
+}
+
+export function trySetStorageItem(
+  getStorage: () => StorageWriter,
+  key: string,
+  value: string,
+): boolean {
+  try {
+    getStorage().setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- clarify that cart totals are estimates affected by final weight, decoration, and personalization
- add a mobile-friendly free-text order details field and include it in the WhatsApp message
- persist order details locally and prevent unavailable browser storage from interrupting the cart

## Validation

- `npm run build`
- manual quota-exhaustion reproduction before and after the storage fix